### PR TITLE
Require EMPIRE_API_URL to be set.

### DIFF
--- a/help.go
+++ b/help.go
@@ -27,7 +27,7 @@ EMPIRE_API_URL
   If username and password are present in the URL, they will
   override .netrc.
 
-  Its default value is https://api.heroku.com/
+  This environment variable is required.
 
 HEROKU_SSL_VERIFY
 

--- a/hkclient/client.go
+++ b/hkclient/client.go
@@ -2,6 +2,7 @@ package hkclient
 
 import (
 	"crypto/tls"
+	"errors"
 	"net"
 	"net/http"
 	"net/url"
@@ -20,12 +21,12 @@ func New(nrc *NetRc, agent string) (*Clients, error) {
 	userAgent := agent + " " + heroku.DefaultUserAgent
 	ste := Clients{}
 
-	disableSSLVerify := false
-	ste.ApiURL = heroku.DefaultAPIURL
-	if s := os.Getenv("EMPIRE_API_URL"); s != "" {
-		ste.ApiURL = s
-		disableSSLVerify = true
+	ste.ApiURL = os.Getenv("EMPIRE_API_URL")
+	if ste.ApiURL == "" {
+		return nil, errors.New("EMPIRE_API_URL must be set")
 	}
+
+	disableSSLVerify := false
 
 	apiURL, err := url.Parse(ste.ApiURL)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,10 @@ import (
 	"testing"
 )
 
+func init() {
+	os.Setenv("EMPIRE_API_URL", "http://localhost:8080")
+}
+
 func TestSSLEnabled(t *testing.T) {
 	initClients()
 


### PR DESCRIPTION
If EMPIRE_API_URL is not set, the CLI will error out with:

``` console
$ emp apps
error: EMPIRE_API_URL must be set
```
