### PR TITLE
Fix run command

### DIFF
--- a/run.go
+++ b/run.go
@@ -131,7 +131,7 @@ func runRun(cmd *Command, args []string) {
 	address := u.Path
 	if protocol != "unix" {
 		protocol = "tcp"
-		address = u.Host
+		address = u.Host + ":80"
 	}
 
 	if u.Scheme == "https" {


### PR DESCRIPTION
Hi, I'm trying empire.
I got following error with `run` command. 

```
$ emp run -a acme-inc /bin/sh
error: dial tcp: missing port in address empire-server-xxxxxxxxxxxx.ap-northeast-1.elb.amazonaws.com
```

some more information about my environment:
- using latest `emp` (cb250c870e4e91f6c1b7acac58540569f377ef9f)
- using `remind101/empire:latest` (`a7490aac0514`)
- ELB for empire is `TCP` mode
- The ELB's `Load Balancer Port` is `80`
- other command works. (e.g. `apps`)

ref: http://golang.org/pkg/net/#Dial
