### PR TITLE
Enable automated packaging

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -1,0 +1,3 @@
+cli: emp
+targets:
+  ubuntu-14.04:

--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -1,3 +1,5 @@
 cli: emp
 targets:
   ubuntu-14.04:
+  centos-7:
+  debian-8:


### PR DESCRIPTION
I've tried running Empire, and it works really great, thanks for that! However the `emp` binary available from the releases page is outdated (the `run` command no longer works for instance), and I think a lot of people would like a proper package to get the latest `emp` binary.

This PR enables automated packaging using [Packager.io](https://packager.io), for a range of recent distributions. I hope this is something of interest to you!
