### PR TITLE
Simplify output of scale -l for better reusability

### DIFF
--- a/scale.go
+++ b/scale.go
@@ -111,7 +111,7 @@ func listScale(appname string) {
 
 	sort.Sort(formations)
 	results := formatResults(formations)
-	log.Printf("%s current scale is %s", appname, strings.Join(results, " "))
+	log.Println(strings.Join(results, " "))
 }
 
 func formatResults(formations []heroku.Formation) []string {


### PR DESCRIPTION
Now the output can be passed directly to `emp scale`
