### PR TITLE
Print to stdout by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -151,6 +151,7 @@ func initClients() {
 
 func main() {
 	log.SetFlags(0)
+	log.SetOutput(os.Stdout)
 
 	// make sure command is specified, disallow global args
 	args := os.Args[1:]


### PR DESCRIPTION
The default logger in package log logs to os.Stderr, which is not really what we want.
